### PR TITLE
Make github hide generated files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Set unix LF EOL for shell scripts
+*.sh text eol=lf
+
+**/zz_generated.*.go linguist-generated=true
+**/types.generated.go linguist-generated=true
+**/generated.pb.go linguist-generated=true
+**/generated.proto linguist-generated=true
+**/types_swagger_doc_generated.go linguist-generated=true


### PR DESCRIPTION
/assign @deads2k
This comes handy when reviewing client-go changes. It's a copy of the attributes we have in origin, just tailored to this project.