### PR TITLE
Add Layers(name string) as a subresource call to image stream

### DIFF
--- a/image/clientset/versioned/typed/image/v1/fake/fake_imagestream_expansion.go
+++ b/image/clientset/versioned/typed/image/v1/fake/fake_imagestream_expansion.go
@@ -1,0 +1,16 @@
+package fake
+
+import (
+	image_v1 "github.com/openshift/api/image/v1"
+	testing "k8s.io/client-go/testing"
+)
+
+// Layers takes name of the imageStream, and returns the corresponding image stream layers object, and an error if there is any.
+func (c *FakeImageStreams) Layers(name string) (result *image_v1.ImageStreamLayers, err error) {
+	obj, err := c.Fake.Invokes(testing.NewGetSubresourceAction(imagestreamsResource, c.ns, "layers", name), &image_v1.ImageStreamLayers{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image_v1.ImageStreamLayers), err
+}

--- a/image/clientset/versioned/typed/image/v1/generated_expansion.go
+++ b/image/clientset/versioned/typed/image/v1/generated_expansion.go
@@ -6,8 +6,6 @@ type ImageExpansion interface{}
 
 type ImageSignatureExpansion interface{}
 
-type ImageStreamExpansion interface{}
-
 type ImageStreamImageExpansion interface{}
 
 type ImageStreamImportExpansion interface{}

--- a/image/clientset/versioned/typed/image/v1/imagestream_expansion.go
+++ b/image/clientset/versioned/typed/image/v1/imagestream_expansion.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	v1 "github.com/openshift/api/image/v1"
+)
+
+// The ImageStreamExpansion interface allows manually adding extra methods to the ImageStream interface.
+type ImageStreamExpansion interface {
+	Layers(name string) (*v1.ImageStreamLayers, error)
+}
+
+// Layers retrieves the image stream layers subresource for the provided image stream, which includes
+// information about the manifests and layers referenced in images that the image stream points to.
+func (c *imageStreams) Layers(name string) (result *v1.ImageStreamLayers, err error) {
+	result = &v1.ImageStreamLayers{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		Name(name).
+		SubResource("layers").
+		Do().
+		Into(result)
+	return
+}


### PR DESCRIPTION
Intended for use with the registry.

Part of https://github.com/openshift/origin/pull/19969