### PR TITLE
Bumps deps to support config.proxy.readinessendpoints

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 595563cffda70c75833adcf07415011d115db7218cbbddc4c14f1684ad39638a
-updated: 2019-07-20T21:53:33.024857-04:00
+updated: 2019-07-18T09:30:31.370860967-07:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8


### PR DESCRIPTION
https://github.com/openshift/api/pull/373 added `ReadinessEndpoints` to proxy type. This PR bumps deps to use new field.