### PR TITLE
Fix replace for go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift/client-go
 go 1.13
 
 require (
-	github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8
+	github.com/openshift/api v0.0.0-20191219134240-52ac50b91cea
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
@@ -11,7 +11,5 @@ require (
 	k8s.io/code-generator v0.17.0
 )
 
-replace (
-	github.com/openshift/api => github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8
-	k8s.io/code-generator => github.com/openshift/kubernetes-code-generator v0.0.0-20191216140939-db549faca3fe
-)
+// needed for pluralization patches open upstream.  Remove in v0.18.0
+replace k8s.io/code-generator => github.com/openshift/kubernetes-code-generator v0.0.0-20191216140939-db549faca3fe

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift/client-go
 go 1.13
 
 require (
-	github.com/openshift/api v0.0.0-20191219134240-52ac50b91cea
+	github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8 h1:s3hqeT+vHJ0xn+4GN5Q20unXo2dQ4X+Ik5uvMEF3cfQ=
-github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6 h1:SxAWPzmw6o8FZ9MMfYqZ6s/DpIadkztdUb+IMyezqY4=
+github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6/go.mod h1:dv+J0b/HWai0QnMVb37/H0v36klkLBi2TNpPeWDxX10=
 github.com/openshift/kubernetes-code-generator v0.0.0-20191216140939-db549faca3fe h1:cqLfxSnplkv+YgeMZxuWnQ2VVeg+XzI6z1T3DRawM40=
 github.com/openshift/kubernetes-code-generator v0.0.0-20191216140939-db549faca3fe/go.mod h1:DVmfPQgxQENqDIzVR2ddLXMH34qeszkKSdH/N+s+38s=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -131,6 +131,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"TopologyManager",                // sig-pod, sjenning
 			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
+			"SCTPSupport",                    // sig-network, ccallend
 		},
 		Disabled: []string{
 			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/vendor/github.com/openshift/api/imageregistry/v1/00-crd.yaml
+++ b/vendor/github.com/openshift/api/imageregistry/v1/00-crd.yaml
@@ -11,6 +11,7 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
+  preserveUnknownFields: false
   subresources:
     status: {}
   validation:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/mailru/easyjson/jwriter
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8 => github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8
+# github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 github.com/openshift/api/apps/v1
 github.com/openshift/api/authorization/v1
 github.com/openshift/api/build/v1


### PR DESCRIPTION
replace stanzas prevent normal go mod vendor of require to match and that in turn impacts transitive dependency calculations downstream.