### PR TITLE
Bug 1952795: Bump openshift/api for cloud network config controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openshift/client-go
 go 1.15
 
 require (
-	github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c
+	github.com/openshift/api v0.0.0-20210423140644-156ca80f8d83
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.21.0-rc.0
 	k8s.io/apimachinery v0.21.0-rc.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c h1:vEOCkpisFTnbTtDfC313LEVmA+d38KEEroN/iABOSlw=
-github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
+github.com/openshift/api v0.0.0-20210423140644-156ca80f8d83 h1:Rz7+q64KDked7wonxYd3r87QAcuiTSt5H+EPghmGMt0=
+github.com/openshift/api v0.0.0-20210423140644-156ca80f8d83/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cloudprivateipconfig.cloud.network.openshift.io
+  name: cloudprivateipconfigs.cloud.network.openshift.io
 spec:
   group: cloud.network.openshift.io
   names:
     kind: CloudPrivateIPConfig
     listKind: CloudPrivateIPConfigList
-    plural: cloudprivateipconfig
+    plural: cloudprivateipconfigs
     singular: cloudprivateipconfig
   scope: Cluster
   versions:

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/generated.proto
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/generated.proto
@@ -28,7 +28,7 @@ option go_package = "v1";
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=cloudprivateipconfig,scope=Cluster
+// +kubebuilder:resource:path=cloudprivateipconfigs,scope=Cluster
 message CloudPrivateIPConfig {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/types.go
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/types.go
@@ -20,7 +20,7 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=cloudprivateipconfig,scope=Cluster
+// +kubebuilder:resource:path=cloudprivateipconfigs,scope=Cluster
 type CloudPrivateIPConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/vendor/github.com/openshift/api/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
+++ b/vendor/github.com/openshift/api/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: helmchartrepositories.helm.openshift.io
@@ -8,7 +8,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec:
   scope: Cluster
-  preserveUnknownFields: false
   group: helm.openshift.io
   names:
     kind: HelmChartRepository
@@ -19,156 +18,156 @@ spec:
   - name: v1beta1
     served: true
     storage: true
-  subresources:
-    status: {}
-  "validation":
-    "openAPIV3Schema":
-      description: HelmChartRepository holds cluster-wide configuration for proxied
-        Helm chart repository
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec holds user settable values for configuration
-          type: object
-          properties:
-            connectionConfig:
-              description: Required configuration for connecting to the chart repo
-              type: object
-              properties:
-                ca:
-                  description: ca is an optional reference to a config map by name
-                    containing the PEM-encoded CA bundle. It is used as a trust anchor
-                    to validate the TLS certificate presented by the remote server.
-                    The key "ca-bundle.crt" is used to locate the data. If empty,
-                    the default system roots are used. The namespace for this config
-                    map is openshift-config.
-                  type: object
-                  required:
-                  - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config
-                        map
-                      type: string
-                tlsClientConfig:
-                  description: tlsClientConfig is an optional reference to a secret
-                    by name that contains the PEM-encoded TLS client certificate and
-                    private key to present when connecting to the server. The key
-                    "tls.crt" is used to locate the client certificate. The key "tls.key"
-                    is used to locate the private key. The namespace for this secret
-                    is openshift-config.
-                  type: object
-                  required:
-                  - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced secret
-                      type: string
-                url:
-                  description: Chart repository URL
-                  type: string
-                  maxLength: 2048
-                  pattern: ^https?:\/\/
-            description:
-              description: Optional human readable repository description, it can
-                be used by UI for displaying purposes
-              type: string
-              maxLength: 2048
-              minLength: 1
-            disabled:
-              description: If set to true, disable the repo usage in the cluster
-              type: boolean
-            name:
-              description: Optional associated human readable repository name, it
-                can be used by UI for displaying purposes
-              type: string
-              maxLength: 100
-              minLength: 1
-        status:
-          description: Observed status of the repository within the cluster..
-          type: object
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their statuses
-              type: array
-              items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,
-                  type FooStatus struct{     // Represents the observations of a foo's
-                  current state.     // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
-                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                  \n     // other fields }"
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: HelmChartRepository holds cluster-wide configuration for proxied
+          Helm chart repository
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            type: object
+            properties:
+              connectionConfig:
+                description: Required configuration for connecting to the chart repo
                 type: object
-                required:
-                - lastTransitionTime
-                - message
-                - reason
-                - status
-                - type
                 properties:
-                  lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another. This should be when
-                      the underlying condition changed.  If that is not known, then
-                      using the time when the API field changed is acceptable.
+                  ca:
+                    description: ca is an optional reference to a config map by name
+                      containing the PEM-encoded CA bundle. It is used as a trust
+                      anchor to validate the TLS certificate presented by the remote
+                      server. The key "ca-bundle.crt" is used to locate the data.
+                      If empty, the default system roots are used. The namespace for
+                      this config map is openshift-config.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced config
+                          map
+                        type: string
+                  tlsClientConfig:
+                    description: tlsClientConfig is an optional reference to a secret
+                      by name that contains the PEM-encoded TLS client certificate
+                      and private key to present when connecting to the server. The
+                      key "tls.crt" is used to locate the client certificate. The
+                      key "tls.key" is used to locate the private key. The namespace
+                      for this secret is openshift-config.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                  url:
+                    description: Chart repository URL
                     type: string
-                    format: date-time
-                  message:
-                    description: message is a human readable message indicating details
-                      about the transition. This may be an empty string.
-                    type: string
-                    maxLength: 32768
-                  observedGeneration:
-                    description: observedGeneration represents the .metadata.generation
-                      that the condition was set based upon. For instance, if .metadata.generation
-                      is currently 12, but the .status.conditions[x].observedGeneration
-                      is 9, the condition is out of date with respect to the current
-                      state of the instance.
-                    type: integer
-                    format: int64
-                    minimum: 0
-                  reason:
-                    description: reason contains a programmatic identifier indicating
-                      the reason for the condition's last transition. Producers of
-                      specific condition types may define expected values and meanings
-                      for this field, and whether the values are considered a guaranteed
-                      API. The value should be a CamelCase string. This field may
-                      not be empty.
-                    type: string
-                    maxLength: 1024
-                    minLength: 1
-                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                  status:
-                    description: status of the condition, one of True, False, Unknown.
-                    type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
-                      like Available, but because arbitrary conditions can be useful
-                      (see .node.status.conditions), the ability to deconflict is
-                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                    type: string
-                    maxLength: 316
-                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    maxLength: 2048
+                    pattern: ^https?:\/\/
+              description:
+                description: Optional human readable repository description, it can
+                  be used by UI for displaying purposes
+                type: string
+                maxLength: 2048
+                minLength: 1
+              disabled:
+                description: If set to true, disable the repo usage in the cluster
+                type: boolean
+              name:
+                description: Optional associated human readable repository name, it
+                  can be used by UI for displaying purposes
+                type: string
+                maxLength: 100
+                minLength: 1
+          status:
+            description: Observed status of the repository within the cluster..
+            type: object
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their statuses
+                type: array
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  type: object
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      type: string
+                      format: date-time
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                      maxLength: 32768
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      type: integer
+                      format: int64
+                      minimum: 0
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/mailru/easyjson/jwriter
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c
+# github.com/openshift/api v0.0.0-20210423140644-156ca80f8d83
 ## explicit
 github.com/openshift/api/apiserver/v1
 github.com/openshift/api/apps/v1


### PR DESCRIPTION
This bumps openshift/api to include the latest changes from https://github.com/openshift/api/pull/910

/assign @sttts 