### PR TITLE
Retract v3.9.0+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,12 @@ replace (
 	k8s.io/code-generator => github.com/openshift/kubernetes-code-generator v0.0.0-20220822200235-042483082c5e
 	k8s.io/kube-openapi => github.com/openshift/kube-openapi v0.0.0-20230324164143-98c122c21a89
 )
+
+// v3.9.0 is the only tag in openshift/client-go and it was created before
+// go.mod was introduced. We retract it so that go command don't select it
+// automatically when resolving versions like @latest.
+retract v3.9.0+incompatible
+
+// To make go aware of the retraction, we need to tag a new version that can be
+// retracted by itself.
+retract v0.0.1


### PR DESCRIPTION
As this repository has the tag v3.9.0 and only it, `go get github.com/openshift/client-go@latest` always resolves into v3.9.0+incompatible. This creates inconvenience for our customers. For example, `@upgrade` cannot pick recent changes, as it's resolved into 3.9.0 and gets rejected as it's older than what our consumers are using now.

To help our clients, we can retract 3.9.0. To make clients aware of this retraction, we need to update go.mod and tag it with something higher than 3.9.0.

See https://go.dev/ref/mod#go-mod-file-retract for details.