### PR TITLE
feat: updated to use prefer protobuf in clients

### DIFF
--- a/apiserver/clientset/versioned/typed/apiserver/v1/apirequestcount.go
+++ b/apiserver/clientset/versioned/typed/apiserver/v1/apirequestcount.go
@@ -53,6 +53,7 @@ func newAPIRequestCounts(c *ApiserverV1Client) *aPIRequestCounts {
 			"",
 			func() *apiserverv1.APIRequestCount { return &apiserverv1.APIRequestCount{} },
 			func() *apiserverv1.APIRequestCountList { return &apiserverv1.APIRequestCountList{} },
+			gentype.PrefersProtobuf[*apiserverv1.APIRequestCount](),
 		),
 	}
 }

--- a/apps/clientset/versioned/typed/apps/v1/deploymentconfig.go
+++ b/apps/clientset/versioned/typed/apps/v1/deploymentconfig.go
@@ -59,6 +59,7 @@ func newDeploymentConfigs(c *AppsV1Client, namespace string) *deploymentConfigs 
 			namespace,
 			func() *appsv1.DeploymentConfig { return &appsv1.DeploymentConfig{} },
 			func() *appsv1.DeploymentConfigList { return &appsv1.DeploymentConfigList{} },
+			gentype.PrefersProtobuf[*appsv1.DeploymentConfig](),
 		),
 	}
 }
@@ -67,6 +68,7 @@ func newDeploymentConfigs(c *AppsV1Client, namespace string) *deploymentConfigs 
 func (c *deploymentConfigs) Instantiate(ctx context.Context, deploymentConfigName string, deploymentRequest *appsv1.DeploymentRequest, opts metav1.CreateOptions) (result *appsv1.DeploymentConfig, err error) {
 	result = &appsv1.DeploymentConfig{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deploymentconfigs").
 		Name(deploymentConfigName).
@@ -82,6 +84,7 @@ func (c *deploymentConfigs) Instantiate(ctx context.Context, deploymentConfigNam
 func (c *deploymentConfigs) Rollback(ctx context.Context, deploymentConfigName string, deploymentConfigRollback *appsv1.DeploymentConfigRollback, opts metav1.CreateOptions) (result *appsv1.DeploymentConfig, err error) {
 	result = &appsv1.DeploymentConfig{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deploymentconfigs").
 		Name(deploymentConfigName).
@@ -97,6 +100,7 @@ func (c *deploymentConfigs) Rollback(ctx context.Context, deploymentConfigName s
 func (c *deploymentConfigs) GetScale(ctx context.Context, deploymentConfigName string, options metav1.GetOptions) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deploymentconfigs").
 		Name(deploymentConfigName).
@@ -111,6 +115,7 @@ func (c *deploymentConfigs) GetScale(ctx context.Context, deploymentConfigName s
 func (c *deploymentConfigs) UpdateScale(ctx context.Context, deploymentConfigName string, scale *v1beta1.Scale, opts metav1.UpdateOptions) (result *v1beta1.Scale, err error) {
 	result = &v1beta1.Scale{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("deploymentconfigs").
 		Name(deploymentConfigName).

--- a/authorization/clientset/versioned/typed/authorization/v1/clusterrole.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/clusterrole.go
@@ -49,6 +49,7 @@ func newClusterRoles(c *AuthorizationV1Client) *clusterRoles {
 			"",
 			func() *authorizationv1.ClusterRole { return &authorizationv1.ClusterRole{} },
 			func() *authorizationv1.ClusterRoleList { return &authorizationv1.ClusterRoleList{} },
+			gentype.PrefersProtobuf[*authorizationv1.ClusterRole](),
 		),
 	}
 }

--- a/authorization/clientset/versioned/typed/authorization/v1/clusterrolebinding.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/clusterrolebinding.go
@@ -49,6 +49,7 @@ func newClusterRoleBindings(c *AuthorizationV1Client) *clusterRoleBindings {
 			"",
 			func() *authorizationv1.ClusterRoleBinding { return &authorizationv1.ClusterRoleBinding{} },
 			func() *authorizationv1.ClusterRoleBindingList { return &authorizationv1.ClusterRoleBindingList{} },
+			gentype.PrefersProtobuf[*authorizationv1.ClusterRoleBinding](),
 		),
 	}
 }

--- a/authorization/clientset/versioned/typed/authorization/v1/localresourceaccessreview.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/localresourceaccessreview.go
@@ -38,6 +38,7 @@ func newLocalResourceAccessReviews(c *AuthorizationV1Client, namespace string) *
 			scheme.ParameterCodec,
 			namespace,
 			func() *authorizationv1.LocalResourceAccessReview { return &authorizationv1.LocalResourceAccessReview{} },
+			gentype.PrefersProtobuf[*authorizationv1.LocalResourceAccessReview](),
 		),
 	}
 }
@@ -46,6 +47,7 @@ func newLocalResourceAccessReviews(c *AuthorizationV1Client, namespace string) *
 func (c *localResourceAccessReviews) Create(ctx context.Context, localResourceAccessReview *authorizationv1.LocalResourceAccessReview, opts metav1.CreateOptions) (result *authorizationv1.ResourceAccessReviewResponse, err error) {
 	result = &authorizationv1.ResourceAccessReviewResponse{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("localresourceaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/authorization/clientset/versioned/typed/authorization/v1/localsubjectaccessreview.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/localsubjectaccessreview.go
@@ -38,6 +38,7 @@ func newLocalSubjectAccessReviews(c *AuthorizationV1Client, namespace string) *l
 			scheme.ParameterCodec,
 			namespace,
 			func() *authorizationv1.LocalSubjectAccessReview { return &authorizationv1.LocalSubjectAccessReview{} },
+			gentype.PrefersProtobuf[*authorizationv1.LocalSubjectAccessReview](),
 		),
 	}
 }
@@ -46,6 +47,7 @@ func newLocalSubjectAccessReviews(c *AuthorizationV1Client, namespace string) *l
 func (c *localSubjectAccessReviews) Create(ctx context.Context, localSubjectAccessReview *authorizationv1.LocalSubjectAccessReview, opts metav1.CreateOptions) (result *authorizationv1.SubjectAccessReviewResponse, err error) {
 	result = &authorizationv1.SubjectAccessReviewResponse{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("localsubjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/authorization/clientset/versioned/typed/authorization/v1/resourceaccessreview.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/resourceaccessreview.go
@@ -38,6 +38,7 @@ func newResourceAccessReviews(c *AuthorizationV1Client) *resourceAccessReviews {
 			scheme.ParameterCodec,
 			"",
 			func() *authorizationv1.ResourceAccessReview { return &authorizationv1.ResourceAccessReview{} },
+			gentype.PrefersProtobuf[*authorizationv1.ResourceAccessReview](),
 		),
 	}
 }
@@ -46,6 +47,7 @@ func newResourceAccessReviews(c *AuthorizationV1Client) *resourceAccessReviews {
 func (c *resourceAccessReviews) Create(ctx context.Context, resourceAccessReview *authorizationv1.ResourceAccessReview, opts metav1.CreateOptions) (result *authorizationv1.ResourceAccessReviewResponse, err error) {
 	result = &authorizationv1.ResourceAccessReviewResponse{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Resource("resourceaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(resourceAccessReview).

--- a/authorization/clientset/versioned/typed/authorization/v1/role.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/role.go
@@ -49,6 +49,7 @@ func newRoles(c *AuthorizationV1Client, namespace string) *roles {
 			namespace,
 			func() *authorizationv1.Role { return &authorizationv1.Role{} },
 			func() *authorizationv1.RoleList { return &authorizationv1.RoleList{} },
+			gentype.PrefersProtobuf[*authorizationv1.Role](),
 		),
 	}
 }

--- a/authorization/clientset/versioned/typed/authorization/v1/rolebinding.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/rolebinding.go
@@ -49,6 +49,7 @@ func newRoleBindings(c *AuthorizationV1Client, namespace string) *roleBindings {
 			namespace,
 			func() *authorizationv1.RoleBinding { return &authorizationv1.RoleBinding{} },
 			func() *authorizationv1.RoleBindingList { return &authorizationv1.RoleBindingList{} },
+			gentype.PrefersProtobuf[*authorizationv1.RoleBinding](),
 		),
 	}
 }

--- a/authorization/clientset/versioned/typed/authorization/v1/rolebindingrestriction.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/rolebindingrestriction.go
@@ -51,6 +51,7 @@ func newRoleBindingRestrictions(c *AuthorizationV1Client, namespace string) *rol
 			func() *authorizationv1.RoleBindingRestrictionList {
 				return &authorizationv1.RoleBindingRestrictionList{}
 			},
+			gentype.PrefersProtobuf[*authorizationv1.RoleBindingRestriction](),
 		),
 	}
 }

--- a/authorization/clientset/versioned/typed/authorization/v1/selfsubjectrulesreview.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/selfsubjectrulesreview.go
@@ -37,6 +37,7 @@ func newSelfSubjectRulesReviews(c *AuthorizationV1Client, namespace string) *sel
 			scheme.ParameterCodec,
 			namespace,
 			func() *authorizationv1.SelfSubjectRulesReview { return &authorizationv1.SelfSubjectRulesReview{} },
+			gentype.PrefersProtobuf[*authorizationv1.SelfSubjectRulesReview](),
 		),
 	}
 }

--- a/authorization/clientset/versioned/typed/authorization/v1/subjectaccessreview.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/subjectaccessreview.go
@@ -38,6 +38,7 @@ func newSubjectAccessReviews(c *AuthorizationV1Client) *subjectAccessReviews {
 			scheme.ParameterCodec,
 			"",
 			func() *authorizationv1.SubjectAccessReview { return &authorizationv1.SubjectAccessReview{} },
+			gentype.PrefersProtobuf[*authorizationv1.SubjectAccessReview](),
 		),
 	}
 }
@@ -46,6 +47,7 @@ func newSubjectAccessReviews(c *AuthorizationV1Client) *subjectAccessReviews {
 func (c *subjectAccessReviews) Create(ctx context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview, opts metav1.CreateOptions) (result *authorizationv1.SubjectAccessReviewResponse, err error) {
 	result = &authorizationv1.SubjectAccessReviewResponse{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Resource("subjectaccessreviews").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(subjectAccessReview).

--- a/authorization/clientset/versioned/typed/authorization/v1/subjectrulesreview.go
+++ b/authorization/clientset/versioned/typed/authorization/v1/subjectrulesreview.go
@@ -37,6 +37,7 @@ func newSubjectRulesReviews(c *AuthorizationV1Client, namespace string) *subject
 			scheme.ParameterCodec,
 			namespace,
 			func() *authorizationv1.SubjectRulesReview { return &authorizationv1.SubjectRulesReview{} },
+			gentype.PrefersProtobuf[*authorizationv1.SubjectRulesReview](),
 		),
 	}
 }

--- a/build/clientset/versioned/typed/build/v1/build.go
+++ b/build/clientset/versioned/typed/build/v1/build.go
@@ -56,6 +56,7 @@ func newBuilds(c *BuildV1Client, namespace string) *builds {
 			namespace,
 			func() *buildv1.Build { return &buildv1.Build{} },
 			func() *buildv1.BuildList { return &buildv1.BuildList{} },
+			gentype.PrefersProtobuf[*buildv1.Build](),
 		),
 	}
 }
@@ -64,6 +65,7 @@ func newBuilds(c *BuildV1Client, namespace string) *builds {
 func (c *builds) UpdateDetails(ctx context.Context, buildName string, build *buildv1.Build, opts metav1.UpdateOptions) (result *buildv1.Build, err error) {
 	result = &buildv1.Build{}
 	err = c.GetClient().Put().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("builds").
 		Name(buildName).
@@ -79,6 +81,7 @@ func (c *builds) UpdateDetails(ctx context.Context, buildName string, build *bui
 func (c *builds) Clone(ctx context.Context, buildName string, buildRequest *buildv1.BuildRequest, opts metav1.CreateOptions) (result *buildv1.Build, err error) {
 	result = &buildv1.Build{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("builds").
 		Name(buildName).

--- a/build/clientset/versioned/typed/build/v1/buildconfig.go
+++ b/build/clientset/versioned/typed/build/v1/buildconfig.go
@@ -55,6 +55,7 @@ func newBuildConfigs(c *BuildV1Client, namespace string) *buildConfigs {
 			namespace,
 			func() *buildv1.BuildConfig { return &buildv1.BuildConfig{} },
 			func() *buildv1.BuildConfigList { return &buildv1.BuildConfigList{} },
+			gentype.PrefersProtobuf[*buildv1.BuildConfig](),
 		),
 	}
 }
@@ -63,6 +64,7 @@ func newBuildConfigs(c *BuildV1Client, namespace string) *buildConfigs {
 func (c *buildConfigs) Instantiate(ctx context.Context, buildConfigName string, buildRequest *buildv1.BuildRequest, opts metav1.CreateOptions) (result *buildv1.Build, err error) {
 	result = &buildv1.Build{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("buildconfigs").
 		Name(buildConfigName).

--- a/cloudnetwork/clientset/versioned/typed/cloudnetwork/v1/cloudprivateipconfig.go
+++ b/cloudnetwork/clientset/versioned/typed/cloudnetwork/v1/cloudprivateipconfig.go
@@ -53,6 +53,7 @@ func newCloudPrivateIPConfigs(c *CloudV1Client) *cloudPrivateIPConfigs {
 			"",
 			func() *cloudnetworkv1.CloudPrivateIPConfig { return &cloudnetworkv1.CloudPrivateIPConfig{} },
 			func() *cloudnetworkv1.CloudPrivateIPConfigList { return &cloudnetworkv1.CloudPrivateIPConfigList{} },
+			gentype.PrefersProtobuf[*cloudnetworkv1.CloudPrivateIPConfig](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/apiserver.go
+++ b/config/clientset/versioned/typed/config/v1/apiserver.go
@@ -53,6 +53,7 @@ func newAPIServers(c *ConfigV1Client) *aPIServers {
 			"",
 			func() *configv1.APIServer { return &configv1.APIServer{} },
 			func() *configv1.APIServerList { return &configv1.APIServerList{} },
+			gentype.PrefersProtobuf[*configv1.APIServer](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/authentication.go
+++ b/config/clientset/versioned/typed/config/v1/authentication.go
@@ -53,6 +53,7 @@ func newAuthentications(c *ConfigV1Client) *authentications {
 			"",
 			func() *configv1.Authentication { return &configv1.Authentication{} },
 			func() *configv1.AuthenticationList { return &configv1.AuthenticationList{} },
+			gentype.PrefersProtobuf[*configv1.Authentication](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/build.go
+++ b/config/clientset/versioned/typed/config/v1/build.go
@@ -49,6 +49,7 @@ func newBuilds(c *ConfigV1Client) *builds {
 			"",
 			func() *configv1.Build { return &configv1.Build{} },
 			func() *configv1.BuildList { return &configv1.BuildList{} },
+			gentype.PrefersProtobuf[*configv1.Build](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/clusteroperator.go
+++ b/config/clientset/versioned/typed/config/v1/clusteroperator.go
@@ -53,6 +53,7 @@ func newClusterOperators(c *ConfigV1Client) *clusterOperators {
 			"",
 			func() *configv1.ClusterOperator { return &configv1.ClusterOperator{} },
 			func() *configv1.ClusterOperatorList { return &configv1.ClusterOperatorList{} },
+			gentype.PrefersProtobuf[*configv1.ClusterOperator](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/clusterversion.go
+++ b/config/clientset/versioned/typed/config/v1/clusterversion.go
@@ -53,6 +53,7 @@ func newClusterVersions(c *ConfigV1Client) *clusterVersions {
 			"",
 			func() *configv1.ClusterVersion { return &configv1.ClusterVersion{} },
 			func() *configv1.ClusterVersionList { return &configv1.ClusterVersionList{} },
+			gentype.PrefersProtobuf[*configv1.ClusterVersion](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/console.go
+++ b/config/clientset/versioned/typed/config/v1/console.go
@@ -53,6 +53,7 @@ func newConsoles(c *ConfigV1Client) *consoles {
 			"",
 			func() *configv1.Console { return &configv1.Console{} },
 			func() *configv1.ConsoleList { return &configv1.ConsoleList{} },
+			gentype.PrefersProtobuf[*configv1.Console](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/dns.go
+++ b/config/clientset/versioned/typed/config/v1/dns.go
@@ -53,6 +53,7 @@ func newDNSes(c *ConfigV1Client) *dNSes {
 			"",
 			func() *configv1.DNS { return &configv1.DNS{} },
 			func() *configv1.DNSList { return &configv1.DNSList{} },
+			gentype.PrefersProtobuf[*configv1.DNS](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/featuregate.go
+++ b/config/clientset/versioned/typed/config/v1/featuregate.go
@@ -53,6 +53,7 @@ func newFeatureGates(c *ConfigV1Client) *featureGates {
 			"",
 			func() *configv1.FeatureGate { return &configv1.FeatureGate{} },
 			func() *configv1.FeatureGateList { return &configv1.FeatureGateList{} },
+			gentype.PrefersProtobuf[*configv1.FeatureGate](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/image.go
+++ b/config/clientset/versioned/typed/config/v1/image.go
@@ -53,6 +53,7 @@ func newImages(c *ConfigV1Client) *images {
 			"",
 			func() *configv1.Image { return &configv1.Image{} },
 			func() *configv1.ImageList { return &configv1.ImageList{} },
+			gentype.PrefersProtobuf[*configv1.Image](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/imagecontentpolicy.go
+++ b/config/clientset/versioned/typed/config/v1/imagecontentpolicy.go
@@ -49,6 +49,7 @@ func newImageContentPolicies(c *ConfigV1Client) *imageContentPolicies {
 			"",
 			func() *configv1.ImageContentPolicy { return &configv1.ImageContentPolicy{} },
 			func() *configv1.ImageContentPolicyList { return &configv1.ImageContentPolicyList{} },
+			gentype.PrefersProtobuf[*configv1.ImageContentPolicy](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/imagedigestmirrorset.go
+++ b/config/clientset/versioned/typed/config/v1/imagedigestmirrorset.go
@@ -53,6 +53,7 @@ func newImageDigestMirrorSets(c *ConfigV1Client) *imageDigestMirrorSets {
 			"",
 			func() *configv1.ImageDigestMirrorSet { return &configv1.ImageDigestMirrorSet{} },
 			func() *configv1.ImageDigestMirrorSetList { return &configv1.ImageDigestMirrorSetList{} },
+			gentype.PrefersProtobuf[*configv1.ImageDigestMirrorSet](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/imagetagmirrorset.go
+++ b/config/clientset/versioned/typed/config/v1/imagetagmirrorset.go
@@ -53,6 +53,7 @@ func newImageTagMirrorSets(c *ConfigV1Client) *imageTagMirrorSets {
 			"",
 			func() *configv1.ImageTagMirrorSet { return &configv1.ImageTagMirrorSet{} },
 			func() *configv1.ImageTagMirrorSetList { return &configv1.ImageTagMirrorSetList{} },
+			gentype.PrefersProtobuf[*configv1.ImageTagMirrorSet](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/infrastructure.go
+++ b/config/clientset/versioned/typed/config/v1/infrastructure.go
@@ -53,6 +53,7 @@ func newInfrastructures(c *ConfigV1Client) *infrastructures {
 			"",
 			func() *configv1.Infrastructure { return &configv1.Infrastructure{} },
 			func() *configv1.InfrastructureList { return &configv1.InfrastructureList{} },
+			gentype.PrefersProtobuf[*configv1.Infrastructure](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/ingress.go
+++ b/config/clientset/versioned/typed/config/v1/ingress.go
@@ -53,6 +53,7 @@ func newIngresses(c *ConfigV1Client) *ingresses {
 			"",
 			func() *configv1.Ingress { return &configv1.Ingress{} },
 			func() *configv1.IngressList { return &configv1.IngressList{} },
+			gentype.PrefersProtobuf[*configv1.Ingress](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/network.go
+++ b/config/clientset/versioned/typed/config/v1/network.go
@@ -53,6 +53,7 @@ func newNetworks(c *ConfigV1Client) *networks {
 			"",
 			func() *configv1.Network { return &configv1.Network{} },
 			func() *configv1.NetworkList { return &configv1.NetworkList{} },
+			gentype.PrefersProtobuf[*configv1.Network](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/node.go
+++ b/config/clientset/versioned/typed/config/v1/node.go
@@ -53,6 +53,7 @@ func newNodes(c *ConfigV1Client) *nodes {
 			"",
 			func() *configv1.Node { return &configv1.Node{} },
 			func() *configv1.NodeList { return &configv1.NodeList{} },
+			gentype.PrefersProtobuf[*configv1.Node](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/oauth.go
+++ b/config/clientset/versioned/typed/config/v1/oauth.go
@@ -53,6 +53,7 @@ func newOAuths(c *ConfigV1Client) *oAuths {
 			"",
 			func() *configv1.OAuth { return &configv1.OAuth{} },
 			func() *configv1.OAuthList { return &configv1.OAuthList{} },
+			gentype.PrefersProtobuf[*configv1.OAuth](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/operatorhub.go
+++ b/config/clientset/versioned/typed/config/v1/operatorhub.go
@@ -53,6 +53,7 @@ func newOperatorHubs(c *ConfigV1Client) *operatorHubs {
 			"",
 			func() *configv1.OperatorHub { return &configv1.OperatorHub{} },
 			func() *configv1.OperatorHubList { return &configv1.OperatorHubList{} },
+			gentype.PrefersProtobuf[*configv1.OperatorHub](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/project.go
+++ b/config/clientset/versioned/typed/config/v1/project.go
@@ -53,6 +53,7 @@ func newProjects(c *ConfigV1Client) *projects {
 			"",
 			func() *configv1.Project { return &configv1.Project{} },
 			func() *configv1.ProjectList { return &configv1.ProjectList{} },
+			gentype.PrefersProtobuf[*configv1.Project](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/proxy.go
+++ b/config/clientset/versioned/typed/config/v1/proxy.go
@@ -53,6 +53,7 @@ func newProxies(c *ConfigV1Client) *proxies {
 			"",
 			func() *configv1.Proxy { return &configv1.Proxy{} },
 			func() *configv1.ProxyList { return &configv1.ProxyList{} },
+			gentype.PrefersProtobuf[*configv1.Proxy](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1/scheduler.go
+++ b/config/clientset/versioned/typed/config/v1/scheduler.go
@@ -53,6 +53,7 @@ func newSchedulers(c *ConfigV1Client) *schedulers {
 			"",
 			func() *configv1.Scheduler { return &configv1.Scheduler{} },
 			func() *configv1.SchedulerList { return &configv1.SchedulerList{} },
+			gentype.PrefersProtobuf[*configv1.Scheduler](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1alpha1/backup.go
+++ b/config/clientset/versioned/typed/config/v1alpha1/backup.go
@@ -53,6 +53,7 @@ func newBackups(c *ConfigV1alpha1Client) *backups {
 			"",
 			func() *configv1alpha1.Backup { return &configv1alpha1.Backup{} },
 			func() *configv1alpha1.BackupList { return &configv1alpha1.BackupList{} },
+			gentype.PrefersProtobuf[*configv1alpha1.Backup](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1alpha1/clusterimagepolicy.go
+++ b/config/clientset/versioned/typed/config/v1alpha1/clusterimagepolicy.go
@@ -53,6 +53,7 @@ func newClusterImagePolicies(c *ConfigV1alpha1Client) *clusterImagePolicies {
 			"",
 			func() *configv1alpha1.ClusterImagePolicy { return &configv1alpha1.ClusterImagePolicy{} },
 			func() *configv1alpha1.ClusterImagePolicyList { return &configv1alpha1.ClusterImagePolicyList{} },
+			gentype.PrefersProtobuf[*configv1alpha1.ClusterImagePolicy](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1alpha1/clustermonitoring.go
+++ b/config/clientset/versioned/typed/config/v1alpha1/clustermonitoring.go
@@ -53,6 +53,7 @@ func newClusterMonitorings(c *ConfigV1alpha1Client) *clusterMonitorings {
 			"",
 			func() *configv1alpha1.ClusterMonitoring { return &configv1alpha1.ClusterMonitoring{} },
 			func() *configv1alpha1.ClusterMonitoringList { return &configv1alpha1.ClusterMonitoringList{} },
+			gentype.PrefersProtobuf[*configv1alpha1.ClusterMonitoring](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1alpha1/imagepolicy.go
+++ b/config/clientset/versioned/typed/config/v1alpha1/imagepolicy.go
@@ -53,6 +53,7 @@ func newImagePolicies(c *ConfigV1alpha1Client, namespace string) *imagePolicies 
 			namespace,
 			func() *configv1alpha1.ImagePolicy { return &configv1alpha1.ImagePolicy{} },
 			func() *configv1alpha1.ImagePolicyList { return &configv1alpha1.ImagePolicyList{} },
+			gentype.PrefersProtobuf[*configv1alpha1.ImagePolicy](),
 		),
 	}
 }

--- a/config/clientset/versioned/typed/config/v1alpha1/insightsdatagather.go
+++ b/config/clientset/versioned/typed/config/v1alpha1/insightsdatagather.go
@@ -53,6 +53,7 @@ func newInsightsDataGathers(c *ConfigV1alpha1Client) *insightsDataGathers {
 			"",
 			func() *configv1alpha1.InsightsDataGather { return &configv1alpha1.InsightsDataGather{} },
 			func() *configv1alpha1.InsightsDataGatherList { return &configv1alpha1.InsightsDataGatherList{} },
+			gentype.PrefersProtobuf[*configv1alpha1.InsightsDataGather](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consoleclidownload.go
+++ b/console/clientset/versioned/typed/console/v1/consoleclidownload.go
@@ -49,6 +49,7 @@ func newConsoleCLIDownloads(c *ConsoleV1Client) *consoleCLIDownloads {
 			"",
 			func() *consolev1.ConsoleCLIDownload { return &consolev1.ConsoleCLIDownload{} },
 			func() *consolev1.ConsoleCLIDownloadList { return &consolev1.ConsoleCLIDownloadList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleCLIDownload](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consoleexternalloglink.go
+++ b/console/clientset/versioned/typed/console/v1/consoleexternalloglink.go
@@ -49,6 +49,7 @@ func newConsoleExternalLogLinks(c *ConsoleV1Client) *consoleExternalLogLinks {
 			"",
 			func() *consolev1.ConsoleExternalLogLink { return &consolev1.ConsoleExternalLogLink{} },
 			func() *consolev1.ConsoleExternalLogLinkList { return &consolev1.ConsoleExternalLogLinkList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleExternalLogLink](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consolelink.go
+++ b/console/clientset/versioned/typed/console/v1/consolelink.go
@@ -49,6 +49,7 @@ func newConsoleLinks(c *ConsoleV1Client) *consoleLinks {
 			"",
 			func() *consolev1.ConsoleLink { return &consolev1.ConsoleLink{} },
 			func() *consolev1.ConsoleLinkList { return &consolev1.ConsoleLinkList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleLink](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consolenotification.go
+++ b/console/clientset/versioned/typed/console/v1/consolenotification.go
@@ -49,6 +49,7 @@ func newConsoleNotifications(c *ConsoleV1Client) *consoleNotifications {
 			"",
 			func() *consolev1.ConsoleNotification { return &consolev1.ConsoleNotification{} },
 			func() *consolev1.ConsoleNotificationList { return &consolev1.ConsoleNotificationList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleNotification](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consoleplugin.go
+++ b/console/clientset/versioned/typed/console/v1/consoleplugin.go
@@ -49,6 +49,7 @@ func newConsolePlugins(c *ConsoleV1Client) *consolePlugins {
 			"",
 			func() *consolev1.ConsolePlugin { return &consolev1.ConsolePlugin{} },
 			func() *consolev1.ConsolePluginList { return &consolev1.ConsolePluginList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsolePlugin](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consolequickstart.go
+++ b/console/clientset/versioned/typed/console/v1/consolequickstart.go
@@ -49,6 +49,7 @@ func newConsoleQuickStarts(c *ConsoleV1Client) *consoleQuickStarts {
 			"",
 			func() *consolev1.ConsoleQuickStart { return &consolev1.ConsoleQuickStart{} },
 			func() *consolev1.ConsoleQuickStartList { return &consolev1.ConsoleQuickStartList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleQuickStart](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consolesample.go
+++ b/console/clientset/versioned/typed/console/v1/consolesample.go
@@ -49,6 +49,7 @@ func newConsoleSamples(c *ConsoleV1Client) *consoleSamples {
 			"",
 			func() *consolev1.ConsoleSample { return &consolev1.ConsoleSample{} },
 			func() *consolev1.ConsoleSampleList { return &consolev1.ConsoleSampleList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleSample](),
 		),
 	}
 }

--- a/console/clientset/versioned/typed/console/v1/consoleyamlsample.go
+++ b/console/clientset/versioned/typed/console/v1/consoleyamlsample.go
@@ -49,6 +49,7 @@ func newConsoleYAMLSamples(c *ConsoleV1Client) *consoleYAMLSamples {
 			"",
 			func() *consolev1.ConsoleYAMLSample { return &consolev1.ConsoleYAMLSample{} },
 			func() *consolev1.ConsoleYAMLSampleList { return &consolev1.ConsoleYAMLSampleList{} },
+			gentype.PrefersProtobuf[*consolev1.ConsoleYAMLSample](),
 		),
 	}
 }

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -22,6 +22,7 @@ for group in apiserver apps authorization build cloudnetwork config console helm
       --output-dir "${SCRIPT_ROOT}/${group}" \
       --plural-exceptions "DNS:DNSes,DNSList:DNSList,SecurityContextConstraints:SecurityContextConstraints" \
       --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.txt" \
+      --prefers-protobuf \
       "${SCRIPT_ROOT}/vendor/github.com/openshift/api"
 done
 

--- a/helm/clientset/versioned/typed/helm/v1beta1/helmchartrepository.go
+++ b/helm/clientset/versioned/typed/helm/v1beta1/helmchartrepository.go
@@ -53,6 +53,7 @@ func newHelmChartRepositories(c *HelmV1beta1Client) *helmChartRepositories {
 			"",
 			func() *helmv1beta1.HelmChartRepository { return &helmv1beta1.HelmChartRepository{} },
 			func() *helmv1beta1.HelmChartRepositoryList { return &helmv1beta1.HelmChartRepositoryList{} },
+			gentype.PrefersProtobuf[*helmv1beta1.HelmChartRepository](),
 		),
 	}
 }

--- a/helm/clientset/versioned/typed/helm/v1beta1/projecthelmchartrepository.go
+++ b/helm/clientset/versioned/typed/helm/v1beta1/projecthelmchartrepository.go
@@ -55,6 +55,7 @@ func newProjectHelmChartRepositories(c *HelmV1beta1Client, namespace string) *pr
 			func() *helmv1beta1.ProjectHelmChartRepositoryList {
 				return &helmv1beta1.ProjectHelmChartRepositoryList{}
 			},
+			gentype.PrefersProtobuf[*helmv1beta1.ProjectHelmChartRepository](),
 		),
 	}
 }

--- a/image/clientset/versioned/typed/image/v1/image.go
+++ b/image/clientset/versioned/typed/image/v1/image.go
@@ -49,6 +49,7 @@ func newImages(c *ImageV1Client) *images {
 			"",
 			func() *imagev1.Image { return &imagev1.Image{} },
 			func() *imagev1.ImageList { return &imagev1.ImageList{} },
+			gentype.PrefersProtobuf[*imagev1.Image](),
 		),
 	}
 }

--- a/image/clientset/versioned/typed/image/v1/imagesignature.go
+++ b/image/clientset/versioned/typed/image/v1/imagesignature.go
@@ -38,6 +38,7 @@ func newImageSignatures(c *ImageV1Client) *imageSignatures {
 			scheme.ParameterCodec,
 			"",
 			func() *imagev1.ImageSignature { return &imagev1.ImageSignature{} },
+			gentype.PrefersProtobuf[*imagev1.ImageSignature](),
 		),
 	}
 }

--- a/image/clientset/versioned/typed/image/v1/imagestream.go
+++ b/image/clientset/versioned/typed/image/v1/imagestream.go
@@ -56,6 +56,7 @@ func newImageStreams(c *ImageV1Client, namespace string) *imageStreams {
 			namespace,
 			func() *imagev1.ImageStream { return &imagev1.ImageStream{} },
 			func() *imagev1.ImageStreamList { return &imagev1.ImageStreamList{} },
+			gentype.PrefersProtobuf[*imagev1.ImageStream](),
 		),
 	}
 }
@@ -64,6 +65,7 @@ func newImageStreams(c *ImageV1Client, namespace string) *imageStreams {
 func (c *imageStreams) Secrets(ctx context.Context, imageStreamName string, options metav1.GetOptions) (result *imagev1.SecretList, err error) {
 	result = &imagev1.SecretList{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("imagestreams").
 		Name(imageStreamName).
@@ -78,6 +80,7 @@ func (c *imageStreams) Secrets(ctx context.Context, imageStreamName string, opti
 func (c *imageStreams) Layers(ctx context.Context, imageStreamName string, options metav1.GetOptions) (result *imagev1.ImageStreamLayers, err error) {
 	result = &imagev1.ImageStreamLayers{}
 	err = c.GetClient().Get().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("imagestreams").
 		Name(imageStreamName).

--- a/image/clientset/versioned/typed/image/v1/imagestreamimage.go
+++ b/image/clientset/versioned/typed/image/v1/imagestreamimage.go
@@ -37,6 +37,7 @@ func newImageStreamImages(c *ImageV1Client, namespace string) *imageStreamImages
 			scheme.ParameterCodec,
 			namespace,
 			func() *imagev1.ImageStreamImage { return &imagev1.ImageStreamImage{} },
+			gentype.PrefersProtobuf[*imagev1.ImageStreamImage](),
 		),
 	}
 }

--- a/image/clientset/versioned/typed/image/v1/imagestreamimport.go
+++ b/image/clientset/versioned/typed/image/v1/imagestreamimport.go
@@ -37,6 +37,7 @@ func newImageStreamImports(c *ImageV1Client, namespace string) *imageStreamImpor
 			scheme.ParameterCodec,
 			namespace,
 			func() *imagev1.ImageStreamImport { return &imagev1.ImageStreamImport{} },
+			gentype.PrefersProtobuf[*imagev1.ImageStreamImport](),
 		),
 	}
 }

--- a/image/clientset/versioned/typed/image/v1/imagestreammapping.go
+++ b/image/clientset/versioned/typed/image/v1/imagestreammapping.go
@@ -40,6 +40,7 @@ func newImageStreamMappings(c *ImageV1Client, namespace string) *imageStreamMapp
 			scheme.ParameterCodec,
 			namespace,
 			func() *apiimagev1.ImageStreamMapping { return &apiimagev1.ImageStreamMapping{} },
+			gentype.PrefersProtobuf[*apiimagev1.ImageStreamMapping](),
 		),
 	}
 }
@@ -48,6 +49,7 @@ func newImageStreamMappings(c *ImageV1Client, namespace string) *imageStreamMapp
 func (c *imageStreamMappings) Create(ctx context.Context, imageStreamMapping *apiimagev1.ImageStreamMapping, opts metav1.CreateOptions) (result *metav1.Status, err error) {
 	result = &metav1.Status{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Namespace(c.GetNamespace()).
 		Resource("imagestreammappings").
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/image/clientset/versioned/typed/image/v1/imagestreamtag.go
+++ b/image/clientset/versioned/typed/image/v1/imagestreamtag.go
@@ -42,6 +42,7 @@ func newImageStreamTags(c *ImageV1Client, namespace string) *imageStreamTags {
 			namespace,
 			func() *imagev1.ImageStreamTag { return &imagev1.ImageStreamTag{} },
 			func() *imagev1.ImageStreamTagList { return &imagev1.ImageStreamTagList{} },
+			gentype.PrefersProtobuf[*imagev1.ImageStreamTag](),
 		),
 	}
 }

--- a/image/clientset/versioned/typed/image/v1/imagetag.go
+++ b/image/clientset/versioned/typed/image/v1/imagetag.go
@@ -42,6 +42,7 @@ func newImageTags(c *ImageV1Client, namespace string) *imageTags {
 			namespace,
 			func() *imagev1.ImageTag { return &imagev1.ImageTag{} },
 			func() *imagev1.ImageTagList { return &imagev1.ImageTagList{} },
+			gentype.PrefersProtobuf[*imagev1.ImageTag](),
 		),
 	}
 }

--- a/imageregistry/clientset/versioned/typed/imageregistry/v1/config.go
+++ b/imageregistry/clientset/versioned/typed/imageregistry/v1/config.go
@@ -53,6 +53,7 @@ func newConfigs(c *ImageregistryV1Client) *configs {
 			"",
 			func() *imageregistryv1.Config { return &imageregistryv1.Config{} },
 			func() *imageregistryv1.ConfigList { return &imageregistryv1.ConfigList{} },
+			gentype.PrefersProtobuf[*imageregistryv1.Config](),
 		),
 	}
 }

--- a/imageregistry/clientset/versioned/typed/imageregistry/v1/imagepruner.go
+++ b/imageregistry/clientset/versioned/typed/imageregistry/v1/imagepruner.go
@@ -53,6 +53,7 @@ func newImagePruners(c *ImageregistryV1Client) *imagePruners {
 			"",
 			func() *imageregistryv1.ImagePruner { return &imageregistryv1.ImagePruner{} },
 			func() *imageregistryv1.ImagePrunerList { return &imageregistryv1.ImagePrunerList{} },
+			gentype.PrefersProtobuf[*imageregistryv1.ImagePruner](),
 		),
 	}
 }

--- a/insights/clientset/versioned/typed/insights/v1alpha1/datagather.go
+++ b/insights/clientset/versioned/typed/insights/v1alpha1/datagather.go
@@ -53,6 +53,7 @@ func newDataGathers(c *InsightsV1alpha1Client) *dataGathers {
 			"",
 			func() *insightsv1alpha1.DataGather { return &insightsv1alpha1.DataGather{} },
 			func() *insightsv1alpha1.DataGatherList { return &insightsv1alpha1.DataGatherList{} },
+			gentype.PrefersProtobuf[*insightsv1alpha1.DataGather](),
 		),
 	}
 }

--- a/machine/clientset/versioned/typed/machine/v1/controlplanemachineset.go
+++ b/machine/clientset/versioned/typed/machine/v1/controlplanemachineset.go
@@ -53,6 +53,7 @@ func newControlPlaneMachineSets(c *MachineV1Client, namespace string) *controlPl
 			namespace,
 			func() *machinev1.ControlPlaneMachineSet { return &machinev1.ControlPlaneMachineSet{} },
 			func() *machinev1.ControlPlaneMachineSetList { return &machinev1.ControlPlaneMachineSetList{} },
+			gentype.PrefersProtobuf[*machinev1.ControlPlaneMachineSet](),
 		),
 	}
 }

--- a/machine/clientset/versioned/typed/machine/v1beta1/machine.go
+++ b/machine/clientset/versioned/typed/machine/v1beta1/machine.go
@@ -53,6 +53,7 @@ func newMachines(c *MachineV1beta1Client, namespace string) *machines {
 			namespace,
 			func() *machinev1beta1.Machine { return &machinev1beta1.Machine{} },
 			func() *machinev1beta1.MachineList { return &machinev1beta1.MachineList{} },
+			gentype.PrefersProtobuf[*machinev1beta1.Machine](),
 		),
 	}
 }

--- a/machine/clientset/versioned/typed/machine/v1beta1/machinehealthcheck.go
+++ b/machine/clientset/versioned/typed/machine/v1beta1/machinehealthcheck.go
@@ -53,6 +53,7 @@ func newMachineHealthChecks(c *MachineV1beta1Client, namespace string) *machineH
 			namespace,
 			func() *machinev1beta1.MachineHealthCheck { return &machinev1beta1.MachineHealthCheck{} },
 			func() *machinev1beta1.MachineHealthCheckList { return &machinev1beta1.MachineHealthCheckList{} },
+			gentype.PrefersProtobuf[*machinev1beta1.MachineHealthCheck](),
 		),
 	}
 }

--- a/machine/clientset/versioned/typed/machine/v1beta1/machineset.go
+++ b/machine/clientset/versioned/typed/machine/v1beta1/machineset.go
@@ -53,6 +53,7 @@ func newMachineSets(c *MachineV1beta1Client, namespace string) *machineSets {
 			namespace,
 			func() *machinev1beta1.MachineSet { return &machinev1beta1.MachineSet{} },
 			func() *machinev1beta1.MachineSetList { return &machinev1beta1.MachineSetList{} },
+			gentype.PrefersProtobuf[*machinev1beta1.MachineSet](),
 		),
 	}
 }

--- a/monitoring/clientset/versioned/typed/monitoring/v1/alertingrule.go
+++ b/monitoring/clientset/versioned/typed/monitoring/v1/alertingrule.go
@@ -53,6 +53,7 @@ func newAlertingRules(c *MonitoringV1Client, namespace string) *alertingRules {
 			namespace,
 			func() *monitoringv1.AlertingRule { return &monitoringv1.AlertingRule{} },
 			func() *monitoringv1.AlertingRuleList { return &monitoringv1.AlertingRuleList{} },
+			gentype.PrefersProtobuf[*monitoringv1.AlertingRule](),
 		),
 	}
 }

--- a/monitoring/clientset/versioned/typed/monitoring/v1/alertrelabelconfig.go
+++ b/monitoring/clientset/versioned/typed/monitoring/v1/alertrelabelconfig.go
@@ -53,6 +53,7 @@ func newAlertRelabelConfigs(c *MonitoringV1Client, namespace string) *alertRelab
 			namespace,
 			func() *monitoringv1.AlertRelabelConfig { return &monitoringv1.AlertRelabelConfig{} },
 			func() *monitoringv1.AlertRelabelConfigList { return &monitoringv1.AlertRelabelConfigList{} },
+			gentype.PrefersProtobuf[*monitoringv1.AlertRelabelConfig](),
 		),
 	}
 }

--- a/network/clientset/versioned/typed/network/v1/clusternetwork.go
+++ b/network/clientset/versioned/typed/network/v1/clusternetwork.go
@@ -49,6 +49,7 @@ func newClusterNetworks(c *NetworkV1Client) *clusterNetworks {
 			"",
 			func() *networkv1.ClusterNetwork { return &networkv1.ClusterNetwork{} },
 			func() *networkv1.ClusterNetworkList { return &networkv1.ClusterNetworkList{} },
+			gentype.PrefersProtobuf[*networkv1.ClusterNetwork](),
 		),
 	}
 }

--- a/network/clientset/versioned/typed/network/v1/egressnetworkpolicy.go
+++ b/network/clientset/versioned/typed/network/v1/egressnetworkpolicy.go
@@ -49,6 +49,7 @@ func newEgressNetworkPolicies(c *NetworkV1Client, namespace string) *egressNetwo
 			namespace,
 			func() *networkv1.EgressNetworkPolicy { return &networkv1.EgressNetworkPolicy{} },
 			func() *networkv1.EgressNetworkPolicyList { return &networkv1.EgressNetworkPolicyList{} },
+			gentype.PrefersProtobuf[*networkv1.EgressNetworkPolicy](),
 		),
 	}
 }

--- a/network/clientset/versioned/typed/network/v1/hostsubnet.go
+++ b/network/clientset/versioned/typed/network/v1/hostsubnet.go
@@ -49,6 +49,7 @@ func newHostSubnets(c *NetworkV1Client) *hostSubnets {
 			"",
 			func() *networkv1.HostSubnet { return &networkv1.HostSubnet{} },
 			func() *networkv1.HostSubnetList { return &networkv1.HostSubnetList{} },
+			gentype.PrefersProtobuf[*networkv1.HostSubnet](),
 		),
 	}
 }

--- a/network/clientset/versioned/typed/network/v1/netnamespace.go
+++ b/network/clientset/versioned/typed/network/v1/netnamespace.go
@@ -49,6 +49,7 @@ func newNetNamespaces(c *NetworkV1Client) *netNamespaces {
 			"",
 			func() *networkv1.NetNamespace { return &networkv1.NetNamespace{} },
 			func() *networkv1.NetNamespaceList { return &networkv1.NetNamespaceList{} },
+			gentype.PrefersProtobuf[*networkv1.NetNamespace](),
 		),
 	}
 }

--- a/network/clientset/versioned/typed/network/v1alpha1/dnsnameresolver.go
+++ b/network/clientset/versioned/typed/network/v1alpha1/dnsnameresolver.go
@@ -53,6 +53,7 @@ func newDNSNameResolvers(c *NetworkV1alpha1Client, namespace string) *dNSNameRes
 			namespace,
 			func() *networkv1alpha1.DNSNameResolver { return &networkv1alpha1.DNSNameResolver{} },
 			func() *networkv1alpha1.DNSNameResolverList { return &networkv1alpha1.DNSNameResolverList{} },
+			gentype.PrefersProtobuf[*networkv1alpha1.DNSNameResolver](),
 		),
 	}
 }

--- a/oauth/clientset/versioned/typed/oauth/v1/oauthaccesstoken.go
+++ b/oauth/clientset/versioned/typed/oauth/v1/oauthaccesstoken.go
@@ -49,6 +49,7 @@ func newOAuthAccessTokens(c *OauthV1Client) *oAuthAccessTokens {
 			"",
 			func() *oauthv1.OAuthAccessToken { return &oauthv1.OAuthAccessToken{} },
 			func() *oauthv1.OAuthAccessTokenList { return &oauthv1.OAuthAccessTokenList{} },
+			gentype.PrefersProtobuf[*oauthv1.OAuthAccessToken](),
 		),
 	}
 }

--- a/oauth/clientset/versioned/typed/oauth/v1/oauthauthorizetoken.go
+++ b/oauth/clientset/versioned/typed/oauth/v1/oauthauthorizetoken.go
@@ -49,6 +49,7 @@ func newOAuthAuthorizeTokens(c *OauthV1Client) *oAuthAuthorizeTokens {
 			"",
 			func() *oauthv1.OAuthAuthorizeToken { return &oauthv1.OAuthAuthorizeToken{} },
 			func() *oauthv1.OAuthAuthorizeTokenList { return &oauthv1.OAuthAuthorizeTokenList{} },
+			gentype.PrefersProtobuf[*oauthv1.OAuthAuthorizeToken](),
 		),
 	}
 }

--- a/oauth/clientset/versioned/typed/oauth/v1/oauthclient.go
+++ b/oauth/clientset/versioned/typed/oauth/v1/oauthclient.go
@@ -49,6 +49,7 @@ func newOAuthClients(c *OauthV1Client) *oAuthClients {
 			"",
 			func() *oauthv1.OAuthClient { return &oauthv1.OAuthClient{} },
 			func() *oauthv1.OAuthClientList { return &oauthv1.OAuthClientList{} },
+			gentype.PrefersProtobuf[*oauthv1.OAuthClient](),
 		),
 	}
 }

--- a/oauth/clientset/versioned/typed/oauth/v1/oauthclientauthorization.go
+++ b/oauth/clientset/versioned/typed/oauth/v1/oauthclientauthorization.go
@@ -49,6 +49,7 @@ func newOAuthClientAuthorizations(c *OauthV1Client) *oAuthClientAuthorizations {
 			"",
 			func() *oauthv1.OAuthClientAuthorization { return &oauthv1.OAuthClientAuthorization{} },
 			func() *oauthv1.OAuthClientAuthorizationList { return &oauthv1.OAuthClientAuthorizationList{} },
+			gentype.PrefersProtobuf[*oauthv1.OAuthClientAuthorization](),
 		),
 	}
 }

--- a/oauth/clientset/versioned/typed/oauth/v1/useroauthaccesstoken.go
+++ b/oauth/clientset/versioned/typed/oauth/v1/useroauthaccesstoken.go
@@ -49,6 +49,7 @@ func newUserOAuthAccessTokens(c *OauthV1Client) *userOAuthAccessTokens {
 			"",
 			func() *oauthv1.UserOAuthAccessToken { return &oauthv1.UserOAuthAccessToken{} },
 			func() *oauthv1.UserOAuthAccessTokenList { return &oauthv1.UserOAuthAccessTokenList{} },
+			gentype.PrefersProtobuf[*oauthv1.UserOAuthAccessToken](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/authentication.go
+++ b/operator/clientset/versioned/typed/operator/v1/authentication.go
@@ -53,6 +53,7 @@ func newAuthentications(c *OperatorV1Client) *authentications {
 			"",
 			func() *operatorv1.Authentication { return &operatorv1.Authentication{} },
 			func() *operatorv1.AuthenticationList { return &operatorv1.AuthenticationList{} },
+			gentype.PrefersProtobuf[*operatorv1.Authentication](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/cloudcredential.go
+++ b/operator/clientset/versioned/typed/operator/v1/cloudcredential.go
@@ -53,6 +53,7 @@ func newCloudCredentials(c *OperatorV1Client) *cloudCredentials {
 			"",
 			func() *operatorv1.CloudCredential { return &operatorv1.CloudCredential{} },
 			func() *operatorv1.CloudCredentialList { return &operatorv1.CloudCredentialList{} },
+			gentype.PrefersProtobuf[*operatorv1.CloudCredential](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/clustercsidriver.go
+++ b/operator/clientset/versioned/typed/operator/v1/clustercsidriver.go
@@ -53,6 +53,7 @@ func newClusterCSIDrivers(c *OperatorV1Client) *clusterCSIDrivers {
 			"",
 			func() *operatorv1.ClusterCSIDriver { return &operatorv1.ClusterCSIDriver{} },
 			func() *operatorv1.ClusterCSIDriverList { return &operatorv1.ClusterCSIDriverList{} },
+			gentype.PrefersProtobuf[*operatorv1.ClusterCSIDriver](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/config.go
+++ b/operator/clientset/versioned/typed/operator/v1/config.go
@@ -53,6 +53,7 @@ func newConfigs(c *OperatorV1Client) *configs {
 			"",
 			func() *operatorv1.Config { return &operatorv1.Config{} },
 			func() *operatorv1.ConfigList { return &operatorv1.ConfigList{} },
+			gentype.PrefersProtobuf[*operatorv1.Config](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/console.go
+++ b/operator/clientset/versioned/typed/operator/v1/console.go
@@ -53,6 +53,7 @@ func newConsoles(c *OperatorV1Client) *consoles {
 			"",
 			func() *operatorv1.Console { return &operatorv1.Console{} },
 			func() *operatorv1.ConsoleList { return &operatorv1.ConsoleList{} },
+			gentype.PrefersProtobuf[*operatorv1.Console](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/csisnapshotcontroller.go
+++ b/operator/clientset/versioned/typed/operator/v1/csisnapshotcontroller.go
@@ -53,6 +53,7 @@ func newCSISnapshotControllers(c *OperatorV1Client) *cSISnapshotControllers {
 			"",
 			func() *operatorv1.CSISnapshotController { return &operatorv1.CSISnapshotController{} },
 			func() *operatorv1.CSISnapshotControllerList { return &operatorv1.CSISnapshotControllerList{} },
+			gentype.PrefersProtobuf[*operatorv1.CSISnapshotController](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/dns.go
+++ b/operator/clientset/versioned/typed/operator/v1/dns.go
@@ -53,6 +53,7 @@ func newDNSes(c *OperatorV1Client) *dNSes {
 			"",
 			func() *operatorv1.DNS { return &operatorv1.DNS{} },
 			func() *operatorv1.DNSList { return &operatorv1.DNSList{} },
+			gentype.PrefersProtobuf[*operatorv1.DNS](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/etcd.go
+++ b/operator/clientset/versioned/typed/operator/v1/etcd.go
@@ -53,6 +53,7 @@ func newEtcds(c *OperatorV1Client) *etcds {
 			"",
 			func() *operatorv1.Etcd { return &operatorv1.Etcd{} },
 			func() *operatorv1.EtcdList { return &operatorv1.EtcdList{} },
+			gentype.PrefersProtobuf[*operatorv1.Etcd](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/ingresscontroller.go
+++ b/operator/clientset/versioned/typed/operator/v1/ingresscontroller.go
@@ -53,6 +53,7 @@ func newIngressControllers(c *OperatorV1Client, namespace string) *ingressContro
 			namespace,
 			func() *operatorv1.IngressController { return &operatorv1.IngressController{} },
 			func() *operatorv1.IngressControllerList { return &operatorv1.IngressControllerList{} },
+			gentype.PrefersProtobuf[*operatorv1.IngressController](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/insightsoperator.go
+++ b/operator/clientset/versioned/typed/operator/v1/insightsoperator.go
@@ -53,6 +53,7 @@ func newInsightsOperators(c *OperatorV1Client) *insightsOperators {
 			"",
 			func() *operatorv1.InsightsOperator { return &operatorv1.InsightsOperator{} },
 			func() *operatorv1.InsightsOperatorList { return &operatorv1.InsightsOperatorList{} },
+			gentype.PrefersProtobuf[*operatorv1.InsightsOperator](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/kubeapiserver.go
+++ b/operator/clientset/versioned/typed/operator/v1/kubeapiserver.go
@@ -53,6 +53,7 @@ func newKubeAPIServers(c *OperatorV1Client) *kubeAPIServers {
 			"",
 			func() *operatorv1.KubeAPIServer { return &operatorv1.KubeAPIServer{} },
 			func() *operatorv1.KubeAPIServerList { return &operatorv1.KubeAPIServerList{} },
+			gentype.PrefersProtobuf[*operatorv1.KubeAPIServer](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/kubecontrollermanager.go
+++ b/operator/clientset/versioned/typed/operator/v1/kubecontrollermanager.go
@@ -53,6 +53,7 @@ func newKubeControllerManagers(c *OperatorV1Client) *kubeControllerManagers {
 			"",
 			func() *operatorv1.KubeControllerManager { return &operatorv1.KubeControllerManager{} },
 			func() *operatorv1.KubeControllerManagerList { return &operatorv1.KubeControllerManagerList{} },
+			gentype.PrefersProtobuf[*operatorv1.KubeControllerManager](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/kubescheduler.go
+++ b/operator/clientset/versioned/typed/operator/v1/kubescheduler.go
@@ -53,6 +53,7 @@ func newKubeSchedulers(c *OperatorV1Client) *kubeSchedulers {
 			"",
 			func() *operatorv1.KubeScheduler { return &operatorv1.KubeScheduler{} },
 			func() *operatorv1.KubeSchedulerList { return &operatorv1.KubeSchedulerList{} },
+			gentype.PrefersProtobuf[*operatorv1.KubeScheduler](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/kubestorageversionmigrator.go
+++ b/operator/clientset/versioned/typed/operator/v1/kubestorageversionmigrator.go
@@ -53,6 +53,7 @@ func newKubeStorageVersionMigrators(c *OperatorV1Client) *kubeStorageVersionMigr
 			"",
 			func() *operatorv1.KubeStorageVersionMigrator { return &operatorv1.KubeStorageVersionMigrator{} },
 			func() *operatorv1.KubeStorageVersionMigratorList { return &operatorv1.KubeStorageVersionMigratorList{} },
+			gentype.PrefersProtobuf[*operatorv1.KubeStorageVersionMigrator](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/machineconfiguration.go
+++ b/operator/clientset/versioned/typed/operator/v1/machineconfiguration.go
@@ -53,6 +53,7 @@ func newMachineConfigurations(c *OperatorV1Client) *machineConfigurations {
 			"",
 			func() *operatorv1.MachineConfiguration { return &operatorv1.MachineConfiguration{} },
 			func() *operatorv1.MachineConfigurationList { return &operatorv1.MachineConfigurationList{} },
+			gentype.PrefersProtobuf[*operatorv1.MachineConfiguration](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/network.go
+++ b/operator/clientset/versioned/typed/operator/v1/network.go
@@ -53,6 +53,7 @@ func newNetworks(c *OperatorV1Client) *networks {
 			"",
 			func() *operatorv1.Network { return &operatorv1.Network{} },
 			func() *operatorv1.NetworkList { return &operatorv1.NetworkList{} },
+			gentype.PrefersProtobuf[*operatorv1.Network](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/olm.go
+++ b/operator/clientset/versioned/typed/operator/v1/olm.go
@@ -53,6 +53,7 @@ func newOLMs(c *OperatorV1Client) *oLMs {
 			"",
 			func() *operatorv1.OLM { return &operatorv1.OLM{} },
 			func() *operatorv1.OLMList { return &operatorv1.OLMList{} },
+			gentype.PrefersProtobuf[*operatorv1.OLM](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/openshiftapiserver.go
+++ b/operator/clientset/versioned/typed/operator/v1/openshiftapiserver.go
@@ -53,6 +53,7 @@ func newOpenShiftAPIServers(c *OperatorV1Client) *openShiftAPIServers {
 			"",
 			func() *operatorv1.OpenShiftAPIServer { return &operatorv1.OpenShiftAPIServer{} },
 			func() *operatorv1.OpenShiftAPIServerList { return &operatorv1.OpenShiftAPIServerList{} },
+			gentype.PrefersProtobuf[*operatorv1.OpenShiftAPIServer](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/openshiftcontrollermanager.go
+++ b/operator/clientset/versioned/typed/operator/v1/openshiftcontrollermanager.go
@@ -53,6 +53,7 @@ func newOpenShiftControllerManagers(c *OperatorV1Client) *openShiftControllerMan
 			"",
 			func() *operatorv1.OpenShiftControllerManager { return &operatorv1.OpenShiftControllerManager{} },
 			func() *operatorv1.OpenShiftControllerManagerList { return &operatorv1.OpenShiftControllerManagerList{} },
+			gentype.PrefersProtobuf[*operatorv1.OpenShiftControllerManager](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/serviceca.go
+++ b/operator/clientset/versioned/typed/operator/v1/serviceca.go
@@ -53,6 +53,7 @@ func newServiceCAs(c *OperatorV1Client) *serviceCAs {
 			"",
 			func() *operatorv1.ServiceCA { return &operatorv1.ServiceCA{} },
 			func() *operatorv1.ServiceCAList { return &operatorv1.ServiceCAList{} },
+			gentype.PrefersProtobuf[*operatorv1.ServiceCA](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/servicecatalogapiserver.go
+++ b/operator/clientset/versioned/typed/operator/v1/servicecatalogapiserver.go
@@ -53,6 +53,7 @@ func newServiceCatalogAPIServers(c *OperatorV1Client) *serviceCatalogAPIServers 
 			"",
 			func() *operatorv1.ServiceCatalogAPIServer { return &operatorv1.ServiceCatalogAPIServer{} },
 			func() *operatorv1.ServiceCatalogAPIServerList { return &operatorv1.ServiceCatalogAPIServerList{} },
+			gentype.PrefersProtobuf[*operatorv1.ServiceCatalogAPIServer](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/servicecatalogcontrollermanager.go
+++ b/operator/clientset/versioned/typed/operator/v1/servicecatalogcontrollermanager.go
@@ -57,6 +57,7 @@ func newServiceCatalogControllerManagers(c *OperatorV1Client) *serviceCatalogCon
 			func() *operatorv1.ServiceCatalogControllerManagerList {
 				return &operatorv1.ServiceCatalogControllerManagerList{}
 			},
+			gentype.PrefersProtobuf[*operatorv1.ServiceCatalogControllerManager](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1/storage.go
+++ b/operator/clientset/versioned/typed/operator/v1/storage.go
@@ -53,6 +53,7 @@ func newStorages(c *OperatorV1Client) *storages {
 			"",
 			func() *operatorv1.Storage { return &operatorv1.Storage{} },
 			func() *operatorv1.StorageList { return &operatorv1.StorageList{} },
+			gentype.PrefersProtobuf[*operatorv1.Storage](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1alpha1/clusterversionoperator.go
+++ b/operator/clientset/versioned/typed/operator/v1alpha1/clusterversionoperator.go
@@ -55,6 +55,7 @@ func newClusterVersionOperators(c *OperatorV1alpha1Client) *clusterVersionOperat
 			func() *operatorv1alpha1.ClusterVersionOperatorList {
 				return &operatorv1alpha1.ClusterVersionOperatorList{}
 			},
+			gentype.PrefersProtobuf[*operatorv1alpha1.ClusterVersionOperator](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1alpha1/etcdbackup.go
+++ b/operator/clientset/versioned/typed/operator/v1alpha1/etcdbackup.go
@@ -53,6 +53,7 @@ func newEtcdBackups(c *OperatorV1alpha1Client) *etcdBackups {
 			"",
 			func() *operatorv1alpha1.EtcdBackup { return &operatorv1alpha1.EtcdBackup{} },
 			func() *operatorv1alpha1.EtcdBackupList { return &operatorv1alpha1.EtcdBackupList{} },
+			gentype.PrefersProtobuf[*operatorv1alpha1.EtcdBackup](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1alpha1/imagecontentsourcepolicy.go
+++ b/operator/clientset/versioned/typed/operator/v1alpha1/imagecontentsourcepolicy.go
@@ -51,6 +51,7 @@ func newImageContentSourcePolicies(c *OperatorV1alpha1Client) *imageContentSourc
 			func() *operatorv1alpha1.ImageContentSourcePolicyList {
 				return &operatorv1alpha1.ImageContentSourcePolicyList{}
 			},
+			gentype.PrefersProtobuf[*operatorv1alpha1.ImageContentSourcePolicy](),
 		),
 	}
 }

--- a/operator/clientset/versioned/typed/operator/v1alpha1/olm.go
+++ b/operator/clientset/versioned/typed/operator/v1alpha1/olm.go
@@ -53,6 +53,7 @@ func newOLMs(c *OperatorV1alpha1Client) *oLMs {
 			"",
 			func() *operatorv1alpha1.OLM { return &operatorv1alpha1.OLM{} },
 			func() *operatorv1alpha1.OLMList { return &operatorv1alpha1.OLMList{} },
+			gentype.PrefersProtobuf[*operatorv1alpha1.OLM](),
 		),
 	}
 }

--- a/operatorcontrolplane/clientset/versioned/typed/operatorcontrolplane/v1alpha1/podnetworkconnectivitycheck.go
+++ b/operatorcontrolplane/clientset/versioned/typed/operatorcontrolplane/v1alpha1/podnetworkconnectivitycheck.go
@@ -57,6 +57,7 @@ func newPodNetworkConnectivityChecks(c *ControlplaneV1alpha1Client, namespace st
 			func() *operatorcontrolplanev1alpha1.PodNetworkConnectivityCheckList {
 				return &operatorcontrolplanev1alpha1.PodNetworkConnectivityCheckList{}
 			},
+			gentype.PrefersProtobuf[*operatorcontrolplanev1alpha1.PodNetworkConnectivityCheck](),
 		),
 	}
 }

--- a/project/clientset/versioned/typed/project/v1/project.go
+++ b/project/clientset/versioned/typed/project/v1/project.go
@@ -53,6 +53,7 @@ func newProjects(c *ProjectV1Client) *projects {
 			"",
 			func() *projectv1.Project { return &projectv1.Project{} },
 			func() *projectv1.ProjectList { return &projectv1.ProjectList{} },
+			gentype.PrefersProtobuf[*projectv1.Project](),
 		),
 	}
 }

--- a/project/clientset/versioned/typed/project/v1/projectrequest.go
+++ b/project/clientset/versioned/typed/project/v1/projectrequest.go
@@ -40,6 +40,7 @@ func newProjectRequests(c *ProjectV1Client) *projectRequests {
 			scheme.ParameterCodec,
 			"",
 			func() *apiprojectv1.ProjectRequest { return &apiprojectv1.ProjectRequest{} },
+			gentype.PrefersProtobuf[*apiprojectv1.ProjectRequest](),
 		),
 	}
 }
@@ -48,6 +49,7 @@ func newProjectRequests(c *ProjectV1Client) *projectRequests {
 func (c *projectRequests) Create(ctx context.Context, projectRequest *apiprojectv1.ProjectRequest, opts metav1.CreateOptions) (result *apiprojectv1.Project, err error) {
 	result = &apiprojectv1.Project{}
 	err = c.GetClient().Post().
+		UseProtobufAsDefault().
 		Resource("projectrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(projectRequest).

--- a/quota/clientset/versioned/typed/quota/v1/appliedclusterresourcequota.go
+++ b/quota/clientset/versioned/typed/quota/v1/appliedclusterresourcequota.go
@@ -39,6 +39,7 @@ func newAppliedClusterResourceQuotas(c *QuotaV1Client, namespace string) *applie
 			namespace,
 			func() *quotav1.AppliedClusterResourceQuota { return &quotav1.AppliedClusterResourceQuota{} },
 			func() *quotav1.AppliedClusterResourceQuotaList { return &quotav1.AppliedClusterResourceQuotaList{} },
+			gentype.PrefersProtobuf[*quotav1.AppliedClusterResourceQuota](),
 		),
 	}
 }

--- a/quota/clientset/versioned/typed/quota/v1/clusterresourcequota.go
+++ b/quota/clientset/versioned/typed/quota/v1/clusterresourcequota.go
@@ -53,6 +53,7 @@ func newClusterResourceQuotas(c *QuotaV1Client) *clusterResourceQuotas {
 			"",
 			func() *quotav1.ClusterResourceQuota { return &quotav1.ClusterResourceQuota{} },
 			func() *quotav1.ClusterResourceQuotaList { return &quotav1.ClusterResourceQuotaList{} },
+			gentype.PrefersProtobuf[*quotav1.ClusterResourceQuota](),
 		),
 	}
 }

--- a/route/clientset/versioned/typed/route/v1/route.go
+++ b/route/clientset/versioned/typed/route/v1/route.go
@@ -53,6 +53,7 @@ func newRoutes(c *RouteV1Client, namespace string) *routes {
 			namespace,
 			func() *routev1.Route { return &routev1.Route{} },
 			func() *routev1.RouteList { return &routev1.RouteList{} },
+			gentype.PrefersProtobuf[*routev1.Route](),
 		),
 	}
 }

--- a/samples/clientset/versioned/typed/samples/v1/config.go
+++ b/samples/clientset/versioned/typed/samples/v1/config.go
@@ -53,6 +53,7 @@ func newConfigs(c *SamplesV1Client) *configs {
 			"",
 			func() *samplesv1.Config { return &samplesv1.Config{} },
 			func() *samplesv1.ConfigList { return &samplesv1.ConfigList{} },
+			gentype.PrefersProtobuf[*samplesv1.Config](),
 		),
 	}
 }

--- a/security/clientset/versioned/typed/security/v1/podsecuritypolicyreview.go
+++ b/security/clientset/versioned/typed/security/v1/podsecuritypolicyreview.go
@@ -37,6 +37,7 @@ func newPodSecurityPolicyReviews(c *SecurityV1Client, namespace string) *podSecu
 			scheme.ParameterCodec,
 			namespace,
 			func() *securityv1.PodSecurityPolicyReview { return &securityv1.PodSecurityPolicyReview{} },
+			gentype.PrefersProtobuf[*securityv1.PodSecurityPolicyReview](),
 		),
 	}
 }

--- a/security/clientset/versioned/typed/security/v1/podsecuritypolicyselfsubjectreview.go
+++ b/security/clientset/versioned/typed/security/v1/podsecuritypolicyselfsubjectreview.go
@@ -39,6 +39,7 @@ func newPodSecurityPolicySelfSubjectReviews(c *SecurityV1Client, namespace strin
 			func() *securityv1.PodSecurityPolicySelfSubjectReview {
 				return &securityv1.PodSecurityPolicySelfSubjectReview{}
 			},
+			gentype.PrefersProtobuf[*securityv1.PodSecurityPolicySelfSubjectReview](),
 		),
 	}
 }

--- a/security/clientset/versioned/typed/security/v1/podsecuritypolicysubjectreview.go
+++ b/security/clientset/versioned/typed/security/v1/podsecuritypolicysubjectreview.go
@@ -37,6 +37,7 @@ func newPodSecurityPolicySubjectReviews(c *SecurityV1Client, namespace string) *
 			scheme.ParameterCodec,
 			namespace,
 			func() *securityv1.PodSecurityPolicySubjectReview { return &securityv1.PodSecurityPolicySubjectReview{} },
+			gentype.PrefersProtobuf[*securityv1.PodSecurityPolicySubjectReview](),
 		),
 	}
 }

--- a/security/clientset/versioned/typed/security/v1/rangeallocation.go
+++ b/security/clientset/versioned/typed/security/v1/rangeallocation.go
@@ -49,6 +49,7 @@ func newRangeAllocations(c *SecurityV1Client) *rangeAllocations {
 			"",
 			func() *securityv1.RangeAllocation { return &securityv1.RangeAllocation{} },
 			func() *securityv1.RangeAllocationList { return &securityv1.RangeAllocationList{} },
+			gentype.PrefersProtobuf[*securityv1.RangeAllocation](),
 		),
 	}
 }

--- a/security/clientset/versioned/typed/security/v1/securitycontextconstraints.go
+++ b/security/clientset/versioned/typed/security/v1/securitycontextconstraints.go
@@ -49,6 +49,7 @@ func newSecurityContextConstraints(c *SecurityV1Client) *securityContextConstrai
 			"",
 			func() *securityv1.SecurityContextConstraints { return &securityv1.SecurityContextConstraints{} },
 			func() *securityv1.SecurityContextConstraintsList { return &securityv1.SecurityContextConstraintsList{} },
+			gentype.PrefersProtobuf[*securityv1.SecurityContextConstraints](),
 		),
 	}
 }

--- a/securityinternal/clientset/versioned/typed/securityinternal/v1/rangeallocation.go
+++ b/securityinternal/clientset/versioned/typed/securityinternal/v1/rangeallocation.go
@@ -49,6 +49,7 @@ func newRangeAllocations(c *SecurityV1Client) *rangeAllocations {
 			"",
 			func() *securityinternalv1.RangeAllocation { return &securityinternalv1.RangeAllocation{} },
 			func() *securityinternalv1.RangeAllocationList { return &securityinternalv1.RangeAllocationList{} },
+			gentype.PrefersProtobuf[*securityinternalv1.RangeAllocation](),
 		),
 	}
 }

--- a/servicecertsigner/clientset/versioned/typed/servicecertsigner/v1alpha1/servicecertsigneroperatorconfig.go
+++ b/servicecertsigner/clientset/versioned/typed/servicecertsigner/v1alpha1/servicecertsigneroperatorconfig.go
@@ -57,6 +57,7 @@ func newServiceCertSignerOperatorConfigs(c *ServicecertsignerV1alpha1Client) *se
 			func() *servicecertsignerv1alpha1.ServiceCertSignerOperatorConfigList {
 				return &servicecertsignerv1alpha1.ServiceCertSignerOperatorConfigList{}
 			},
+			gentype.PrefersProtobuf[*servicecertsignerv1alpha1.ServiceCertSignerOperatorConfig](),
 		),
 	}
 }

--- a/sharedresource/clientset/versioned/typed/sharedresource/v1alpha1/sharedconfigmap.go
+++ b/sharedresource/clientset/versioned/typed/sharedresource/v1alpha1/sharedconfigmap.go
@@ -55,6 +55,7 @@ func newSharedConfigMaps(c *SharedresourceV1alpha1Client) *sharedConfigMaps {
 			func() *sharedresourcev1alpha1.SharedConfigMapList {
 				return &sharedresourcev1alpha1.SharedConfigMapList{}
 			},
+			gentype.PrefersProtobuf[*sharedresourcev1alpha1.SharedConfigMap](),
 		),
 	}
 }

--- a/sharedresource/clientset/versioned/typed/sharedresource/v1alpha1/sharedsecret.go
+++ b/sharedresource/clientset/versioned/typed/sharedresource/v1alpha1/sharedsecret.go
@@ -53,6 +53,7 @@ func newSharedSecrets(c *SharedresourceV1alpha1Client) *sharedSecrets {
 			"",
 			func() *sharedresourcev1alpha1.SharedSecret { return &sharedresourcev1alpha1.SharedSecret{} },
 			func() *sharedresourcev1alpha1.SharedSecretList { return &sharedresourcev1alpha1.SharedSecretList{} },
+			gentype.PrefersProtobuf[*sharedresourcev1alpha1.SharedSecret](),
 		),
 	}
 }

--- a/template/clientset/versioned/typed/template/v1/brokertemplateinstance.go
+++ b/template/clientset/versioned/typed/template/v1/brokertemplateinstance.go
@@ -49,6 +49,7 @@ func newBrokerTemplateInstances(c *TemplateV1Client) *brokerTemplateInstances {
 			"",
 			func() *templatev1.BrokerTemplateInstance { return &templatev1.BrokerTemplateInstance{} },
 			func() *templatev1.BrokerTemplateInstanceList { return &templatev1.BrokerTemplateInstanceList{} },
+			gentype.PrefersProtobuf[*templatev1.BrokerTemplateInstance](),
 		),
 	}
 }

--- a/template/clientset/versioned/typed/template/v1/template.go
+++ b/template/clientset/versioned/typed/template/v1/template.go
@@ -49,6 +49,7 @@ func newTemplates(c *TemplateV1Client, namespace string) *templates {
 			namespace,
 			func() *templatev1.Template { return &templatev1.Template{} },
 			func() *templatev1.TemplateList { return &templatev1.TemplateList{} },
+			gentype.PrefersProtobuf[*templatev1.Template](),
 		),
 	}
 }

--- a/template/clientset/versioned/typed/template/v1/templateinstance.go
+++ b/template/clientset/versioned/typed/template/v1/templateinstance.go
@@ -53,6 +53,7 @@ func newTemplateInstances(c *TemplateV1Client, namespace string) *templateInstan
 			namespace,
 			func() *templatev1.TemplateInstance { return &templatev1.TemplateInstance{} },
 			func() *templatev1.TemplateInstanceList { return &templatev1.TemplateInstanceList{} },
+			gentype.PrefersProtobuf[*templatev1.TemplateInstance](),
 		),
 	}
 }

--- a/user/clientset/versioned/typed/user/v1/group.go
+++ b/user/clientset/versioned/typed/user/v1/group.go
@@ -49,6 +49,7 @@ func newGroups(c *UserV1Client) *groups {
 			"",
 			func() *userv1.Group { return &userv1.Group{} },
 			func() *userv1.GroupList { return &userv1.GroupList{} },
+			gentype.PrefersProtobuf[*userv1.Group](),
 		),
 	}
 }

--- a/user/clientset/versioned/typed/user/v1/identity.go
+++ b/user/clientset/versioned/typed/user/v1/identity.go
@@ -49,6 +49,7 @@ func newIdentities(c *UserV1Client) *identities {
 			"",
 			func() *userv1.Identity { return &userv1.Identity{} },
 			func() *userv1.IdentityList { return &userv1.IdentityList{} },
+			gentype.PrefersProtobuf[*userv1.Identity](),
 		),
 	}
 }

--- a/user/clientset/versioned/typed/user/v1/user.go
+++ b/user/clientset/versioned/typed/user/v1/user.go
@@ -49,6 +49,7 @@ func newUsers(c *UserV1Client) *users {
 			"",
 			func() *userv1.User { return &userv1.User{} },
 			func() *userv1.UserList { return &userv1.UserList{} },
+			gentype.PrefersProtobuf[*userv1.User](),
 		),
 	}
 }

--- a/user/clientset/versioned/typed/user/v1/useridentitymapping.go
+++ b/user/clientset/versioned/typed/user/v1/useridentitymapping.go
@@ -40,6 +40,7 @@ func newUserIdentityMappings(c *UserV1Client) *userIdentityMappings {
 			scheme.ParameterCodec,
 			"",
 			func() *userv1.UserIdentityMapping { return &userv1.UserIdentityMapping{} },
+			gentype.PrefersProtobuf[*userv1.UserIdentityMapping](),
 		),
 	}
 }


### PR DESCRIPTION
The primary need here is that MOM tests on Auth operator started failing when bumping to latest kube, upstream client-go uses this new flag for code gen so updating our client-go to follow the same pattern and resolve MOM failures.